### PR TITLE
Mandatory scale

### DIFF
--- a/0.4/examples/invalid/missing_scale.json
+++ b/0.4/examples/invalid/missing_scale.json
@@ -1,0 +1,30 @@
+{
+    "multiscales": [
+        {
+            "axes": [
+                {
+                    "name": "y",
+                    "type": "space",
+                    "units": "micrometer"
+                },
+                {
+                    "name": "x",
+                    "type": "space",
+                    "units": "micrometer"
+                }
+            ],
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {
+                            "translation": [1, 1],
+                            "type": "translation"
+                        }
+                    ]
+                }
+            ],
+            "version": "0.4"
+        }
+    ]
+}

--- a/0.4/schemas/image.schema
+++ b/0.4/schemas/image.schema
@@ -26,6 +26,24 @@
                 "coordinateTransformations": {
                   "type": "array",
                   "minItems": 1,
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "scale"
+                        ]
+                      },
+                      "scale": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
                   "items": {
                     "oneOf": [
                       {


### PR DESCRIPTION
Enforces that at least one `scale` element will be defined in `coordinateTransformations`  for each individual dataset alongside an additional invalid example.